### PR TITLE
Add notebook documenting a11yhood data access

### DIFF
--- a/documentation/reading-a11yhood-data.ipynb
+++ b/documentation/reading-a11yhood-data.ipynb
@@ -5,11 +5,11 @@
    "id": "8bc14362",
    "metadata": {},
    "source": [
-    "# reading the a11yhood data\n",
+    "# Reading the A11yhood Data\n",
     "\n",
-    "this document describes existing approaches for accessing data in the a11yhood supabase.\n",
+    "This document describes existing approaches for accessing data in the a11yhood supabase.\n",
     "\n",
-    "## TLDR\n",
+    "## TL;DR\n",
     "\n",
     "* seed scripts are for local dev/test data and assume a writable database\n",
     "* direct `supabase` access needs shared auth via `SUPABASE_URL` and `SUPABASE_KEY`\n",
@@ -34,7 +34,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "it seems there are three ways to do this.\n",
+    "It seems there are three ways to do this.\n",
     "\n",
     "1. run the `seed_scripts` base scripts\n",
     "2. use the `supabase` api directly\n",
@@ -46,7 +46,7 @@
    "id": "97671135",
    "metadata": {},
    "source": [
-    "## seed scripts\n",
+    "## `seed_scripts`\n",
     "\n",
     "- Runtime: Python 3 in the backend env (run via `uv run python ...` or `python ...`).\n",
     "- Dependencies: database access plus the backend packages (notably `python-dotenv`, `sqlalchemy`, and `supabase` used across the scripts).\n",
@@ -61,7 +61,7 @@
    "source": [
     "## connecting with `supabase` directly\n",
     "\n",
-    "the seed scripts are wrappers around `supabase` so we still need auth to access the data."
+    "The seed scripts are wrappers around `supabase` so we still need auth to access the data."
    ]
   },
   {


### PR DESCRIPTION
Add documentation/reading-a11yhood-data.ipynb: a newcomer notebook that describes three approaches to read a11yhood data — running local seed scripts, connecting to Supabase directly (requires SUPABASE_URL and SUPABASE_KEY), and scraping the public REST API. Includes example code (hishel.httpx + pandas) that fetches /api/products, a sample DataFrame output, and practical guidance about auth, rate limits, caching, and when to prefer a bulk archive. Notes an example KeyError in the notebook code where the SUPABASE key name is mistyped.